### PR TITLE
Add id property to LibraryRoot

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -141,7 +141,7 @@ def container_handler(request, usage_key_string):
                 prev_url = None
                 next_url = None
                 index = 1
-                parent_url = reverse_library_url('library_handler', courselike.id)
+                parent_url = reverse_library_url('library_handler', courselike.location.course_key)
                 xblock_info = create_xblock_info(xblock)
                 context_name = 'context_library'
             else:

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -141,7 +141,7 @@ def container_handler(request, usage_key_string):
                 prev_url = None
                 next_url = None
                 index = 1
-                parent_url = reverse_library_url('library_handler', courselike.location.course_key)
+                parent_url = reverse_library_url('library_handler', courselike.id)
                 xblock_info = create_xblock_info(xblock)
                 context_name = 'context_library'
             else:
@@ -314,7 +314,7 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
     component_types = _filter_disabled_blocks(component_types)
 
     # Filter out discussion component from component_types if non-legacy discussion provider is configured for course
-    component_types = _filter_discussion_for_non_legacy_provider(component_types, courselike.location.course_key)
+    component_types = _filter_discussion_for_non_legacy_provider(component_types, courselike.id)
 
     # Content Libraries currently don't allow opting in to unsupported xblocks/problem types.
     allow_unsupported = getattr(courselike, "allow_unsupported_xblocks", False)

--- a/common/lib/xmodule/xmodule/library_root_xblock.py
+++ b/common/lib/xmodule/xmodule/library_root_xblock.py
@@ -118,6 +118,11 @@ class LibraryRoot(XBlock):
         )
 
     @property
+    def id(self):
+        """Return the course_id for this course"""
+        return self.location.course_key
+
+    @property
     def display_org_with_default(self):
         """
         Org display names are not implemented. This just provides API compatibility with CourseBlock.


### PR DESCRIPTION
Add an `id` property to the `LibraryRoot` class to match `CourseBlock` and allow the code handling these two objects to be more similar and simple.