### PR TITLE
Allow settings to specify which xblocks to track in StudentModuleHistory

### DIFF
--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -188,6 +188,7 @@ class BaseStudentModuleHistory(models.Model):
     # Using an inner class with a getter to simulate a classproperty
     # Similar to an instance's @property, but doesn't require a reference to an instance
     # Class.HISTORY_SAVING_TYPES is accessed without calling a method
+    # Must be calculated in order to avoid referencing settings before django is initialized
     class HistorySavingTypes:
         def __get__(self, *args, **kwargs):
             return getattr(settings, 'HISTORY_SAVING_TYPES', {'problem'})

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -188,7 +188,7 @@ class BaseStudentModuleHistory(models.Model):
     # Using an inner class with a getter to simulate a classproperty
     # Similar to an instance's @property, but doesn't require a reference to an instance
     # Class.HISTORY_SAVING_TYPES is accessed without calling a method
-    # Must be calculated in order to avoid referencing settings before django is initialized
+    # The value but must be calculated real-time to avoid referencing settings before django is initialized
     class HistorySavingTypes:
         def __get__(self, *args, **kwargs):
             return getattr(settings, 'HISTORY_SAVING_TYPES', {'problem'})

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -184,7 +184,15 @@ class BaseStudentModuleHistory(models.Model):
     .. no_pii:
     """
     objects = ChunkingManager()
-    HISTORY_SAVING_TYPES = {'problem'}
+
+    # Using an inner class with a getter to simulate a classproperty
+    # Similar to an instance's @property, but doesn't require a reference to an instance
+    # Class.HISTORY_SAVING_TYPES is accessed without calling a method
+    class HistorySavingTypes:
+        def __get__(self, *args, **kwargs):
+            return getattr(settings, 'HISTORY_SAVING_TYPES', {'problem'})
+
+    HISTORY_SAVING_TYPES = HistorySavingTypes()
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Pull from settings the set of module types to track in StudentModuleHistory. This allows support for custom xblocks to be tracked, in addition to the native "problem" xblock.