### PR TITLE
[MRI-5356] Add Override to `_attach_profile_claim` Function

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -7,7 +7,7 @@ from time import time
 
 from django.conf import settings
 from edx_django_utils.monitoring import set_custom_attribute
-from edx_django_utils.plugins import pluggable_override
+from edx_django_utils.plugins import pluggable_override  # @medality_custom
 from edx_rbac.utils import create_role_auth_claim_for_user
 from jwkest import jwk
 from jwkest.jws import JWS
@@ -231,7 +231,7 @@ def _attach_email_claim(payload, user):
     payload['email'] = user.email
 
 
-@pluggable_override("OVERRIDE_ATTACH_PROFILE_CLAIM")
+@pluggable_override("OVERRIDE_ATTACH_PROFILE_CLAIM")  # @medality_custom
 def _attach_profile_claim(payload, user):
     """Add the profile claim details to the JWT payload."""
     try:

--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -7,6 +7,7 @@ from time import time
 
 from django.conf import settings
 from edx_django_utils.monitoring import set_custom_attribute
+from edx_django_utils.plugins import pluggable_override
 from edx_rbac.utils import create_role_auth_claim_for_user
 from jwkest import jwk
 from jwkest.jws import JWS
@@ -230,6 +231,7 @@ def _attach_email_claim(payload, user):
     payload['email'] = user.email
 
 
+@pluggable_override("OVERRIDE_ATTACH_PROFILE_CLAIM")
 def _attach_profile_claim(payload, user):
     """Add the profile claim details to the JWT payload."""
     try:


### PR DESCRIPTION
Add pluggable override to `_attach_profile_claim` function so that we can set a custom "name" parameter (instead of deriving it from `UserProfile.objects.get(user=user).name`).