### PR TITLE
[MRI-5583] add robots.txt config to LMS

### DIFF
--- a/lms/templates/robots.txt
+++ b/lms/templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -9,7 +9,7 @@ from django.contrib import admin
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.urls import include, path, re_path
 from django.utils.translation import gettext_lazy as _
-from django.views.generic.base import RedirectView
+from django.views.generic.base import RedirectView, TemplateView
 from edx_api_doc_tools import make_docs_urls
 from edx_django_utils.plugins import get_plugin_url_patterns
 
@@ -1029,4 +1029,8 @@ urlpatterns += [
 # MFE API urls
 urlpatterns += [
     path('api/mfe_config/v1', include(('lms.djangoapps.mfe_config_api.urls', 'lms.djangoapps.mfe_config_api'), namespace='mfe_config_api'))
+]
+
+urlpatterns += [
+    path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),
 ]


### PR DESCRIPTION
Implemented following https://gist.github.com/jramnai/1d97d8bc6877e44e065b3ee861fb3b48. The error reported in https://mrionline.atlassian.net/browse/MRI-5583 is being caused by bot traffic to the LMS.