### PR TITLE
[MRI-4839] Use Tag Name Instead of Hard-Coded Import Path

### DIFF
--- a/xmodule/html_module.py
+++ b/xmodule/html_module.py
@@ -253,7 +253,7 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
             # 'filename' in html pointers is a relative path
             # (not same as 'html/blah.html' when the pointer is in a directory itself)
             pointer_path = "{category}/{url_path}".format(
-                category='html',
+                category=xml_object.tag, #  @medality_custom
                 url_path=name_to_pathname(location.block_id)
             )
             base = path(pointer_path).dirname()


### PR DESCRIPTION
The import process expects HTML files that correspond to each HTML XBlock to exist within a `/html/` directory in an exported course's .gz file.

Our case history blocks get put into a `/case_history/` folder—this PR updates the import process to dynamically use the block's category string within the filepath instead of a hard-coded value of 'html'.