### PR TITLE
[MRI-5684] Disable `ambra_case_list` In Studio XBlock Options

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -59,7 +59,15 @@ COMPONENT_TYPES = [
     'vimeo',
 ]
 
-ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes() if name != "ambra_case_list"} - set(COMPONENT_TYPES))
+ADVANCED_COMPONENT_TYPES = sorted(
+    {
+        name for name, class_ in XBlock.load_classes()
+        # TODO MRI-5684 - remove this exclusion
+        # once ambra_case_list class is deleted.
+        if name != "ambra_case_list"
+    }
+    - set(COMPONENT_TYPES)
+)
 
 ADVANCED_PROBLEM_TYPES = settings.ADVANCED_PROBLEM_TYPES
 

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -47,7 +47,6 @@ log = logging.getLogger(__name__)
 # @medality_custom
 COMPONENT_TYPES = [
     'ambra',
-    'ambra_case_list',
     'ambra_quiz',
     'case_history',
     'drag_and_drop',
@@ -311,7 +310,6 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
     # @medality_custom
     component_display_names = {
         'ambra': _("Ambra Link"),
-        'ambra_case_list': _("Ambra Case List"),
         'case_history': _("Ambra Case History"),
         'ambra_quiz': _("Ambra Quiz"),
         'drag_and_drop': _("Drag and Drop"),

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -59,7 +59,7 @@ COMPONENT_TYPES = [
     'vimeo',
 ]
 
-ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes()} - set(COMPONENT_TYPES))
+ADVANCED_COMPONENT_TYPES = sorted({name for name, class_ in XBlock.load_classes() if name != "ambra_case_list"} - set(COMPONENT_TYPES))
 
 ADVANCED_PROBLEM_TYPES = settings.ADVANCED_PROBLEM_TYPES
 


### PR DESCRIPTION
Remove `ambra_case_list` from the list of xblock types the user can select when creating new xblocks in studio.