### PR TITLE
Changes needed for Premiere CE OAuth Integration

### DIFF
--- a/common/djangoapps/entitlements/rest_api/v1/serializers.py
+++ b/common/djangoapps/entitlements/rest_api/v1/serializers.py
@@ -50,6 +50,7 @@ class CourseEntitlementSupportDetailSerializer(serializers.ModelSerializer):
         slug_field='username',
         default=serializers.CurrentUserDefault()
     )
+    # @medality_custom: this was a fix to a syntax error
     unenrolled_run = CourseKeyField(source='unenrolled_run.id')
 
     class Meta:

--- a/common/djangoapps/entitlements/rest_api/v1/serializers.py
+++ b/common/djangoapps/entitlements/rest_api/v1/serializers.py
@@ -50,7 +50,7 @@ class CourseEntitlementSupportDetailSerializer(serializers.ModelSerializer):
         slug_field='username',
         default=serializers.CurrentUserDefault()
     )
-    unenrolled_run = CourseKeyField('unenrolled_run.id')
+    unenrolled_run = CourseKeyField(source='unenrolled_run.id')
 
     class Meta:
         model = CourseEntitlementSupportDetail

--- a/common/djangoapps/entitlements/rest_api/v1/serializers.py
+++ b/common/djangoapps/entitlements/rest_api/v1/serializers.py
@@ -50,7 +50,7 @@ class CourseEntitlementSupportDetailSerializer(serializers.ModelSerializer):
         slug_field='username',
         default=serializers.CurrentUserDefault()
     )
-    # unenrolled_run = CourseKeyField('unenrolled_run.id')
+    unenrolled_run = CourseKeyField('unenrolled_run.id')
 
     class Meta:
         model = CourseEntitlementSupportDetail
@@ -58,6 +58,6 @@ class CourseEntitlementSupportDetailSerializer(serializers.ModelSerializer):
             'support_user',
             'action',
             'comments',
-            # 'unenrolled_run',
+            'unenrolled_run',
             'created'
         )

--- a/common/djangoapps/entitlements/rest_api/v1/serializers.py
+++ b/common/djangoapps/entitlements/rest_api/v1/serializers.py
@@ -50,7 +50,7 @@ class CourseEntitlementSupportDetailSerializer(serializers.ModelSerializer):
         slug_field='username',
         default=serializers.CurrentUserDefault()
     )
-    unenrolled_run = CourseKeyField('unenrolled_run.id')
+    # unenrolled_run = CourseKeyField('unenrolled_run.id')
 
     class Meta:
         model = CourseEntitlementSupportDetail
@@ -58,6 +58,6 @@ class CourseEntitlementSupportDetailSerializer(serializers.ModelSerializer):
             'support_user',
             'action',
             'comments',
-            'unenrolled_run',
+            # 'unenrolled_run',
             'created'
         )

--- a/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
+++ b/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
@@ -65,14 +65,16 @@ class DOTAdapter:
         """
         Given a token string, return the matching AccessToken object.
         """
-        return models.AccessToken.objects.get(token=token_string)
+        # @medality_custom
+        return models.get_access_token_model().objects.get(token=token_string)
 
     def create_access_token_for_test(self, token_string, client, user, expires):
         """
         Returns a new AccessToken object created from the given arguments.
         This method is currently used only by tests.
         """
-        return models.AccessToken.objects.create(
+        # @medality_custom
+        return models.get_access_token_model().objects.create(
             token=token_string,
             application=client,
             user=user,

--- a/openedx/core/djangoapps/oauth_dispatch/admin.py
+++ b/openedx/core/djangoapps/oauth_dispatch/admin.py
@@ -29,8 +29,8 @@ def reregister(model_class):
 
     return decorator
 
-
-@reregister(models.AccessToken)
+# @medality_custom
+@reregister(models.get_access_token_model())
 class DOTAccessTokenAdmin(ModelAdmin):
     """
     Custom AccessToken Admin

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -8,7 +8,8 @@ from datetime import datetime, timedelta
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
-from oauth2_provider.models import AccessToken
+# @medality_custom
+from oauth2_provider import models
 from oauth2_provider.oauth2_validators import OAuth2Validator
 from oauth2_provider.scopes import get_scopes_backend
 from pytz import utc
@@ -17,7 +18,8 @@ from ..models import RestrictedApplication
 # pylint: disable=W0223
 
 
-@receiver(pre_save, sender=AccessToken)
+# @medality_custom
+@receiver(pre_save, sender=models.get_access_token_model())
 def on_access_token_presave(sender, instance, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Mark AccessTokens as expired for 'restricted applications' if required.
@@ -108,7 +110,8 @@ class EdxOAuth2Validator(OAuth2Validator):
         # and calculate expires_in (in seconds) from the database value. This
         # value should be a negative value, meaning that it is already expired.
         if RestrictedApplication.should_expire_access_token(client):
-            access_token = AccessToken.objects.get(token=token['access_token'])
+            # @medality_custom
+            access_token = models.get_access_token_model().objects.get(token=token['access_token'])
             expires_in = (access_token.expires - _get_utc_now()).total_seconds()
             assert expires_in < 0
             token['expires_in'] = expires_in
@@ -126,7 +129,8 @@ class EdxOAuth2Validator(OAuth2Validator):
         """
         expires_in = getattr(request, 'expires_in', None)
         if expires_in:
-            access_token = AccessToken.objects.get(token=token['access_token'])
+            # @medality_custom
+            access_token = models.get_access_token_model().objects.get(token=token['access_token'])
             access_token.expires = _get_utc_now() + timedelta(seconds=expires_in)
             access_token.save()
             token['expires_in'] = expires_in

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -14,7 +14,10 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.http import http_date, parse_http_date
 from edx_rest_framework_extensions.auth.jwt import cookies as jwt_cookies
 from edx_rest_framework_extensions.auth.jwt.constants import JWT_DELIMITER
-from oauth2_provider.models import Application
+# @medality_custom start
+# from oauth2_provider.models import Application
+from django.apps import apps
+# @medality_custom end
 from common.djangoapps.student.models import UserProfile
 
 from openedx.core.djangoapps.oauth_dispatch.adapters import DOTAdapter
@@ -354,6 +357,8 @@ def _get_login_oauth_client():
     Returns the configured OAuth Client/Application used for Login.
     """
     login_client_id = settings.JWT_AUTH['JWT_LOGIN_CLIENT_ID']
+    # @medality_custom
+    Application = apps.get_model(settings.OAUTH2_PROVIDER_APPLICATION_MODEL)
     try:
         return Application.objects.get(client_id=login_client_id)
     except Application.DoesNotExist:

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -14,10 +14,8 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.http import http_date, parse_http_date
 from edx_rest_framework_extensions.auth.jwt import cookies as jwt_cookies
 from edx_rest_framework_extensions.auth.jwt.constants import JWT_DELIMITER
-# @medality_custom start
-# from oauth2_provider.models import Application
-from django.apps import apps
-# @medality_custom end
+# @medality_custom
+from oauth2_provider import models as oauth_models
 from common.djangoapps.student.models import UserProfile
 
 from openedx.core.djangoapps.oauth_dispatch.adapters import DOTAdapter
@@ -358,7 +356,7 @@ def _get_login_oauth_client():
     """
     login_client_id = settings.JWT_AUTH['JWT_LOGIN_CLIENT_ID']
     # @medality_custom
-    Application = apps.get_model(settings.OAUTH2_PROVIDER_APPLICATION_MODEL)
+    Application = oauth_models.get_application_model()
     try:
         return Application.objects.get(client_id=login_client_id)
     except Application.DoesNotExist:

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -3,6 +3,10 @@
 import logging
 
 import django.utils.timezone
+# @medality_custom start
+from django.apps import apps
+from django.conf import settings
+# @medality_custom end
 from oauth2_provider import models as dot_models
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
@@ -92,7 +96,9 @@ class BearerAuthentication(BaseAuthentication):
             })
         else:
             user = token.user
-            has_application = dot_models.Application.objects.filter(user_id=user.id)
+            # @medality_custom start
+            Application = apps.get_model(settings.OAUTH2_PROVIDER_APPLICATION_MODEL)
+            has_application = Application.objects.filter(user_id=user.id)
             if not user.has_usable_password() and not has_application:
                 msg = 'User disabled by admin: %s' % user.get_username()
                 raise AuthenticationFailed({


### PR DESCRIPTION
This PR does a few things:
- The oauth2_provider package supports swappable models, but in a handful of cases the edx-platform uses the native models directly rather than going through the helper methods which prevents us from defining custom models in our code base. This PR fixes that problem.
- Fixes an unrelated syntax error in CourseEntitlementSupportDetailSerializer that was preventing migrations from running for me
- Adds an extra call to validate the token so we can have a place to hook into for gating access to PCE