### PR TITLE
[MRI-7228] Add case_report icon class support

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -66,3 +66,9 @@ ENABLE_COURSE_UPDATE_NOTIFICATIONS = CourseWaffleFlag(
     f'{WAFFLE_NAMESPACE}.enable_course_update_notifications',
     __name__
 )
+
+
+# @medality_custom
+ENABLE_CASE_REPORT_XBLOCK = WaffleSwitch(
+    f'{WAFFLE_NAMESPACE}.enable_case_report_xblock', __name__
+)

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -29,6 +29,7 @@ from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
 from cms.djangoapps.contentstore.helpers import is_unit
 from cms.djangoapps.contentstore.toggles import use_new_problem_editor, use_new_unit_page
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import load_services_for_studio
+from medality_openedx_plugin.waffle import ENABLE_CASE_REPORT_XBLOCK # @medality_custom
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.core.djangoapps.content_tagging.api import get_object_tags
@@ -49,7 +50,6 @@ COMPONENT_TYPES = [
     'ambra_quiz',
     'case_file',
     'case_history',
-    'case_report',
     'drag_and_drop',
     'html',
     'pdf',
@@ -252,6 +252,10 @@ def get_component_templates(courselike, library=False):  # lint-amnesty, pylint:
     # The component_templates array is in the order of "advanced" (if present), followed
     # by the components in the order listed in COMPONENT_TYPES.
     component_types = COMPONENT_TYPES[:]
+    
+    # @medality_custom
+    if ENABLE_CASE_REPORT_XBLOCK.is_enabled():
+        component_types.append('case_report')
 
     # Libraries do not support discussions, drag-and-drop, and openassessment and other libraries
     # @medality_custom

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -26,10 +26,10 @@ from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
+from cms.djangoapps.contentstore.config.waffle import ENABLE_CASE_REPORT_XBLOCK
 from cms.djangoapps.contentstore.helpers import is_unit
 from cms.djangoapps.contentstore.toggles import use_new_problem_editor, use_new_unit_page
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import load_services_for_studio
-from medality_openedx_plugin.waffle import ENABLE_CASE_REPORT_XBLOCK # @medality_custom
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.core.djangoapps.content_tagging.api import get_object_tags

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -26,7 +26,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.xblock_django.api import authorable_xblocks, disabled_xblocks
 from common.djangoapps.xblock_django.models import XBlockStudioConfigurationFlag
-from cms.djangoapps.contentstore.config.waffle import ENABLE_CASE_REPORT_XBLOCK
+from cms.djangoapps.contentstore.config.waffle import ENABLE_CASE_REPORT_XBLOCK # @medality_custom
 from cms.djangoapps.contentstore.helpers import is_unit
 from cms.djangoapps.contentstore.toggles import use_new_problem_editor, use_new_unit_page
 from cms.djangoapps.contentstore.xblock_storage_handlers.view_handlers import load_services_for_studio

--- a/xmodule/assets/sequence/_display.scss
+++ b/xmodule/assets/sequence/_display.scss
@@ -145,7 +145,8 @@ $seq-nav-height: 50px;
         }
 
         //other
-        &.seq_other {
+        // @medality_custom: case report icon
+        &.seq_other, &.seq_case_report {
           .icon::before {
             content: "\f02d"; // .fa-book
           }

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -32,7 +32,8 @@ _ = lambda text: text
 
 # HACK: This shouldn't be hard-coded to two types
 # OBSOLETE: This obsoletes 'type'
-CLASS_PRIORITY = ['video', 'problem']
+# @medality_custom
+CLASS_PRIORITY = ['video', 'problem', 'case_report']
 
 
 class VerticalFields:


### PR DESCRIPTION
Related to: https://github.com/Medality-Health/medality/pull/2642

This is to improving the reporting experience, otherwise case report units will be type `other` in the new `completions` field added in the related PR.

This also adds support for feature flagging the case report xblock.